### PR TITLE
Add LED output for ESP32-C3 night light

### DIFF
--- a/night-light/README.md
+++ b/night-light/README.md
@@ -1,0 +1,12 @@
+# Night Light
+
+ESPHome configuration for driving a single white LED with an ESP32-C3 Super Mini and exposing it to Home Assistant.
+
+## Wiring
+
+- Connect GPIO4 to the anode of the LED through a suitable current-limiting resistor (around 330Ω).
+- Connect the cathode of the LED to GND.
+- Power the ESP32-C3 Super Mini via its 5V or 3.3V input as required.
+
+With this wiring the LED can be turned on/off and dimmed from Home Assistant.
+

--- a/night-light/night-light.yaml
+++ b/night-light/night-light.yaml
@@ -29,4 +29,14 @@ wifi:
     password: "srzKngrhekmG"
 
 captive_portal:
-    
+
+output:
+  - platform: ledc
+    pin: GPIO4
+    id: white_led_output
+
+light:
+  - platform: monochromatic
+    name: "White LED"
+    output: white_led_output
+    restore_mode: ALWAYS_OFF


### PR DESCRIPTION
## Summary
- drive ESP32-C3 Super Mini white LED via PWM on GPIO4
- document wiring for connecting the LED and power

## Testing
- `esphome config night-light/night-light.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68b6cc13c990832bbb7e68793e1f4db6